### PR TITLE
avoid creating a new file if user has specified the flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"log"
 	"os"
 	"time"
 )
 
+var noCreate = flag.Bool("c", false, "do not create any files")
+
 func main() {
 	if len(os.Args) == 1 {
 		log.Fatal("Usage: touch <file1, file2 ... fileN>\n")
 	}
+	flag.BoolVar(noCreate, "no-create", false, "do not create any files")
+	flag.Parse()
 
-	for _, file := range os.Args[1:] {
+	for _, file := range flag.Args() {
 		switch fi, err := os.Stat(file); {
 		case errors.Is(err, os.ErrNotExist): // we don't have the file, create it.
 			create(file)
@@ -25,6 +30,9 @@ func main() {
 }
 
 func create(file string) {
+	if *noCreate {
+		return
+	}
 	f, err := os.Create(file)
 	if err != nil {
 		log.Fatalf("create: cannot create the file %q: %v\n", file, err)


### PR DESCRIPTION
Allow flags. If user doens't want new files, turn the `create` function into a no op.