### PR TITLE
Ref time

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const format = time.RFC3339
+
 var (
 	newTime       time.Time = time.Now().UTC()
 	noCreate                = flag.Bool("c", false, "do not create any files")
@@ -15,6 +17,7 @@ var (
 	help                    = flag.Bool("help", false, "displays this help text and exits")
 	modOnly                 = flag.Bool("m", false, "only changes the modified time")
 	referenceFile           = flag.String("r", "", "use the specified file's times instead of the current system time")
+	userTime                = flag.String("t", "", "-t sets a specified time instead of the default current system time")
 )
 
 func init() {
@@ -32,6 +35,7 @@ func init() {
 		os.Exit(0)
 	}
 
+	// Date from a reference file takes precedence over any supplied date string in this implementation. Check for either.
 	if len(*referenceFile) > 0 {
 		switch fi, err := os.Stat(*referenceFile); {
 		default:
@@ -43,5 +47,13 @@ func init() {
 		case err != nil:
 			os.Exit(2)
 		}
+	} else if *userTime != "" {
+		t, err := time.Parse(format, *userTime)
+		if err != nil {
+			log.Printf("%q is invalid as a date of format: %q\n", *userTime, format)
+			os.Exit(1)
+		}
+		newTime = t
+		useCurrentTime = false
 	}
 }

--- a/flags.go
+++ b/flags.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"log"
 	"os"
@@ -8,22 +9,39 @@ import (
 )
 
 var (
-	newTime      time.Time = time.Now().UTC()
-	noCreate               = flag.Bool("c", false, "do not create any files")
-	accessedOnly           = flag.Bool("a", false, "only changes the accessed time")
-	help                   = flag.Bool("help", false, "displays this help text and exits")
-	modOnly                = flag.Bool("m", false, "only changes the modified time")
+	newTime       time.Time = time.Now().UTC()
+	noCreate                = flag.Bool("c", false, "do not create any files")
+	accessedOnly            = flag.Bool("a", false, "only changes the accessed time")
+	help                    = flag.Bool("help", false, "displays this help text and exits")
+	modOnly                 = flag.Bool("m", false, "only changes the modified time")
+	referenceFile           = flag.String("r", "", "use the specified file's times instead of the current system time")
 )
 
 func init() {
 	if len(os.Args) == 1 {
 		log.Fatal("Usage: touch <file1, file2 ... fileN>\n")
 	}
+
 	flag.BoolVar(noCreate, "no-create", false, "do not create any files")
+	flag.StringVar(referenceFile, "reference", "", "use this file's times insead of current time")
+
 	flag.Parse()
 
 	if *help {
 		flag.Usage()
 		os.Exit(0)
+	}
+
+	if len(*referenceFile) > 0 {
+		switch fi, err := os.Stat(*referenceFile); {
+		default:
+			newTime = fi.ModTime()
+			useCurrentTime = false
+		case errors.Is(err, os.ErrNotExist):
+			log.Printf("touch: failed to get attributes of %q: No such file or directory\n", *referenceFile)
+			fallthrough
+		case err != nil:
+			os.Exit(2)
+		}
 	}
 }

--- a/operations.go
+++ b/operations.go
@@ -12,11 +12,18 @@ func create(file string) {
 	if *noCreate {
 		return
 	}
+
 	f, err := os.Create(file)
 	if err != nil {
 		log.Fatalf("create: cannot create the file %q: %v\n", file, err)
 	}
 	f.Close()
+
+	// We can set the date to the one picked by the user...
+	if !useCurrentTime {
+		fi, _ := os.Stat(file) // It shouldn't fail seeing as we just created the file a nanosecond ago (or so)...
+		touch(fi)
+	}
 }
 
 func touch(fi os.FileInfo) {

--- a/operations.go
+++ b/operations.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+var useCurrentTime = true
+
 func create(file string) {
 	if *noCreate {
 		return


### PR DESCRIPTION
Implement the following

1. -r or --reference flag to allow the user to pick a reference file. The modified date from this file will be used in all files touched by this session
2. -t flag for the user to specify a custom date/time string. Only rudimentary support so far. The only format supported is RFC3339. Custom parsing will be added later