### PR TITLE
Exit codes

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -22,7 +22,8 @@ var (
 
 func init() {
 	if len(os.Args) == 1 {
-		log.Fatal("Usage: touch <file1, file2 ... fileN>\n")
+		println("Usage: touch <file1, file2 ... fileN>\n")
+		os.Exit(noFilesExitCode)
 	}
 
 	flag.BoolVar(noCreate, "no-create", false, "do not create any files")
@@ -32,7 +33,7 @@ func init() {
 
 	if *help {
 		flag.Usage()
-		os.Exit(0)
+		os.Exit(normalExitCode)
 	}
 
 	// Date from a reference file takes precedence over any supplied date string in this implementation. Check for either.
@@ -45,13 +46,13 @@ func init() {
 			log.Printf("touch: failed to get attributes of %q: No such file or directory\n", *referenceFile)
 			fallthrough
 		case err != nil:
-			os.Exit(2)
+			os.Exit(readFileAttributeExitCode)
 		}
 	} else if *userTime != "" {
 		t, err := time.Parse(format, *userTime)
 		if err != nil {
 			log.Printf("%q is invalid as a date of format: %q\n", *userTime, format)
-			os.Exit(1)
+			os.Exit(parseTimeExitCode)
 		}
 		newTime = t
 		useCurrentTime = false

--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ func main() {
 		case errors.Is(err, os.ErrNotExist): // we don't have the file, create it.
 			create(file)
 		case err != nil:
-			log.Fatalf("Could not touch the file %q: %v\n", file, err)
+			log.Printf("Could not touch the file %q: %v\n", file, err)
+			os.Exit(readFileAttributeExitCode)
 		default:
 			touch(fi)
 		}

--- a/operations.go
+++ b/operations.go
@@ -26,7 +26,8 @@ func create(file string) {
 
 	f, err := os.Create(file)
 	if err != nil {
-		log.Fatalf("create: cannot create the file %q: %v\n", file, err)
+		log.Printf("create: cannot create the file %q: %v\n", file, err)
+		os.Exit(createFileExitCode)
 	}
 	f.Close()
 

--- a/operations.go
+++ b/operations.go
@@ -6,6 +6,17 @@ import (
 	"time"
 )
 
+// The various exit codes used by touch when something goes wrong. Add new ones to the end to avoid changing these
+const (
+	normalExitCode = iota
+	_              // Skipping code 1 to leave it as unclassified in cases we use log.Fatal or log.Fatalf since that uses exit code 1.
+	unrecognizedFlagExitCode
+	noFilesExitCode
+	createFileExitCode
+	parseTimeExitCode
+	readFileAttributeExitCode
+)
+
 var useCurrentTime = true
 
 func create(file string) {


### PR DESCRIPTION
Use consistent exit codes to allow for documentation of codes used in the program.